### PR TITLE
Indicate in options, whether images are currently loaded or not

### DIFF
--- a/app/src/main/java/com/github/dfa/diaspora_android/activity/MainActivity.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/activity/MainActivity.java
@@ -968,21 +968,26 @@ public class MainActivity extends AppCompatActivity
             }
             break;
 
-            case R.id.nav_settings_view: {
-                final CharSequence[] options = {getString(R.string.settings_font), getString(R.string.settings_view), getString(R.string.settings_image)};
+            case R.id.nav_settings_view:
+            {
+                final CharSequence[] options = {getString(R.string.settings_font), getString(R.string.settings_view), appSettings.isLoadImages() ?
+                        getString(R.string.settings_images_switch_off) : getString(R.string.settings_images_switch_on)};
+
                 if (Helpers.isOnline(MainActivity.this)) {
                     new AlertDialog.Builder(MainActivity.this)
                             .setItems(options, new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int item) {
-                                    if (options[item].equals(getString(R.string.settings_font)))
-                                        alertFormElements();
-                                    if (options[item].equals(getString(R.string.settings_view)))
-                                        webView.loadUrl("https://" + podDomain + "/mobile/toggle");
-                                    if (options[item].equals(getString(R.string.settings_image)))
-                                        webSettings.setLoadsImagesAutomatically(!appSettings.isLoadImages());
-                                    appSettings.setLoadImages(!appSettings.isLoadImages());
-                                    webView.loadUrl(webView.getUrl());
+                                    switch(item) {
+                                        case 0: alertFormElements();
+                                            break;
+                                        case 1: webView.loadUrl("https://" + podDomain + "/mobile/toggle");
+                                            break;
+                                        case 2: webSettings.setLoadsImagesAutomatically(!appSettings.isLoadImages());
+                                            appSettings.setLoadImages(!appSettings.isLoadImages());
+                                            webView.loadUrl(webView.getUrl());
+                                            break;
+                                    }
                                 }
                             }).show();
                 } else {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -153,5 +153,7 @@ along with this program.  If not, see http://www.gnu.org/licenses.&lt;br> &lt;br
     <string name="jb_profile">Profil</string>
     <string name="new_post1">D* nur Text</string>
     <string name="shared_by_diaspora_android">*[geteilt durch #diaspora-android]*</string>
+    <string name="settings_images_switch_off">Bilder nicht laden</string>
+    <string name="settings_images_switch_on">Bilder laden</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,8 @@
 
     <string name="settings_font">Change font size</string>
     <string name="settings_image">Toggle image loading</string>
+    <string name="settings_images_switch_on">Do load images</string>
+    <string name="settings_images_switch_off">Do not load images</string>
     <string name="settings_view">Change view</string>
     <string name="share_link">Share link as text</string>
     <string name="share_screenshot">Share screenshot of webpage</string>


### PR DESCRIPTION
Hi!
It annoyed me not to know, whether I turned the do-not-load-images-feature on or off the last time I used the app. So I changed the options menu to indicate the current status by telling the user whether he wants to activate or deactivate loading images.
