### PR TITLE
Fix settings and add an option to clear cache

### DIFF
--- a/app/src/main/java/com/github/dfa/diaspora_android/activity/MainActivity.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/activity/MainActivity.java
@@ -111,6 +111,7 @@ public class MainActivity extends AppCompatActivity
 
     public static final String ACTION_OPEN_URL = "com.github.dfa.diaspora_android.MainActivity.open_url";
     public static final String ACTION_CHANGE_ACCOUNT = "com.github.dfa.diaspora_android.MainActivity.change_account";
+    public static final String ACTION_CLEAR_CACHE = "com.github.dfa.diaspora_android.MainActivity.clear_cache";
     public static final String URL_MESSAGE = "URL_MESSAGE";
 
     private App app;
@@ -438,6 +439,8 @@ public class MainActivity extends AppCompatActivity
         } else if(ACTION_CHANGE_ACCOUNT.equals(action)) {
             app.resetPodData(webView);
             Helpers.animateToActivity(MainActivity.this, PodSelectionActivity.class, true);
+        } else if(ACTION_CLEAR_CACHE.equals(action)) {
+            webView.clearCache(true);
         }
     }
 

--- a/app/src/main/java/com/github/dfa/diaspora_android/activity/MainActivity.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/activity/MainActivity.java
@@ -108,8 +108,9 @@ public class MainActivity extends AppCompatActivity
     static final int INPUT_FILE_REQUEST_CODE = 1;
     private static final int REQUEST_CODE_ASK_PERMISSIONS = 123;
     public static final int REQUEST_CODE_ASK_PERMISSIONS_SAVE_IMAGE = 124;
-    public static final int REQUEST_CODE_SETTINGS = 125;
-    public static final int RESULT_CODE_CHANGE_ACCOUNT = 130;
+
+    public static final String ACTION_OPEN_URL = "com.github.dfa.diaspora_android.MainActivity.open_url";
+    public static final String ACTION_CHANGE_ACCOUNT = "com.github.dfa.diaspora_android.MainActivity.change_account";
     public static final String URL_MESSAGE = "URL_MESSAGE";
 
     private App app;
@@ -243,6 +244,8 @@ public class MainActivity extends AppCompatActivity
                 snackbarNoInternet.show();
             }
         }
+
+        handleIntent(getIntent());
     }
 
     private void setupWebView(Bundle savedInstanceState) {
@@ -420,18 +423,26 @@ public class MainActivity extends AppCompatActivity
         );
     }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        handleIntent(intent);
+    }
+
+    private void handleIntent(Intent intent) {
+        String action = intent.getAction();
+        if(ACTION_OPEN_URL.equals(action)) {
+            String url = intent.getStringExtra(URL_MESSAGE);
+            webView.loadUrl(url);
+        } else if(ACTION_CHANGE_ACCOUNT.equals(action)) {
+            app.resetPodData(webView);
+            Helpers.animateToActivity(MainActivity.this, PodSelectionActivity.class, true);
+        }
+    }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if(requestCode == REQUEST_CODE_SETTINGS) {
-            if(resultCode == Activity.RESULT_OK) {
-                String url = data.getStringExtra(URL_MESSAGE);
-                webView.loadUrl(url);
-            } else if(resultCode == RESULT_CODE_CHANGE_ACCOUNT) {
-                app.resetPodData(webView);
-                Helpers.animateToActivity(MainActivity.this, PodSelectionActivity.class, true);
-            }
-        }
         if (requestCode != INPUT_FILE_REQUEST_CODE || mFilePathCallback == null) {
             super.onActivityResult(requestCode, resultCode, data);
             return;
@@ -931,7 +942,7 @@ public class MainActivity extends AppCompatActivity
             break;
 
             case R.id.nav_settings_app: {
-                startActivityForResult(new Intent(this, SettingsActivity.class), REQUEST_CODE_SETTINGS);
+                startActivity(new Intent(this, SettingsActivity.class));
             }
             break;
 

--- a/app/src/main/java/com/github/dfa/diaspora_android/activity/SettingsActivity.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/activity/SettingsActivity.java
@@ -94,6 +94,9 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
                                 })
                         .show();
                 return true;
+            case "pref_key_clear_cache":
+                intent.setAction(MainActivity.ACTION_CLEAR_CACHE);
+                break;
             default:
                 intent = null;
                 break;

--- a/app/src/main/java/com/github/dfa/diaspora_android/activity/SettingsActivity.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/activity/SettingsActivity.java
@@ -1,6 +1,5 @@
 package com.github.dfa.diaspora_android.activity;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -31,7 +30,6 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
         sharedPreferences = getPreferenceScreen().getSharedPreferences();
         sharedPreferences.registerOnSharedPreferenceChangeListener(this);
         setPreferenceSummaries();
-        setResult(Activity.RESULT_CANCELED);
         sharedPreferences.edit().putBoolean(AppSettings.PREF.PROXY_WAS_ENABLED,
                 sharedPreferences.getBoolean(AppSettings.PREF.PROXY_ENABLED, false)).apply();
     }
@@ -65,21 +63,21 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 
     @Override
     public boolean onPreferenceTreeClick(PreferenceScreen screen, Preference preference) {
-        Intent results = new Intent();
+        Intent intent = new Intent(this, MainActivity.class);
         String podDomain = ((App)getApplication()).getSettings().getPodDomain();
         switch(preference.getKey()) {
             case "pref_key_personal_settings":
-                results.putExtra(MainActivity.URL_MESSAGE, "https://" + podDomain + "/user/edit");
-                setResult(Activity.RESULT_OK, results);
-                finish();
+                intent.setAction(MainActivity.ACTION_OPEN_URL);
+                intent.putExtra(MainActivity.URL_MESSAGE, "https://" + podDomain + "/user/edit");
+                break;
             case "pref_key_manage_tags":
-                results.putExtra(MainActivity.URL_MESSAGE, "https://" + podDomain + "/tag_followings/manage");
-                setResult(Activity.RESULT_OK, results);
-                finish();
+                intent.setAction(MainActivity.ACTION_OPEN_URL);
+                intent.putExtra(MainActivity.URL_MESSAGE, "https://" + podDomain + "/tag_followings/manage");
+                break;
             case "pref_key_manage_contacts":
-                results.putExtra(MainActivity.URL_MESSAGE, "https://" + podDomain + "/contacts");
-                setResult(Activity.RESULT_OK, results);
-                finish();
+                intent.setAction(MainActivity.ACTION_OPEN_URL);
+                intent.putExtra(MainActivity.URL_MESSAGE, "https://" + podDomain + "/contacts");
+                break;
             case "pref_key_change_account":
                 new AlertDialog.Builder(SettingsActivity.this)
                         .setTitle(getString(R.string.confirmation))
@@ -88,11 +86,22 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
                         .setPositiveButton(android.R.string.yes,
                                 new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface dialog, int id) {
-                                        setResult(MainActivity.RESULT_CODE_CHANGE_ACCOUNT);
+                                        Intent intent = new Intent(SettingsActivity.this, MainActivity.class);
+                                        intent.setAction(MainActivity.ACTION_CHANGE_ACCOUNT);
+                                        startActivity(intent);
                                         finish();
                                     }
                                 })
                         .show();
+                return true;
+            default:
+                intent = null;
+                break;
+        }
+        if(intent != null) {
+            startActivity(intent);
+            finish();
+            return true;
         }
         return super.onPreferenceTreeClick(screen, preference);
     }

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -46,4 +46,7 @@
     <string name="pref_desc_change_account">Erase local session data and switch to another Diaspora pod/account</string>
     <string name="pref_warning_change_account">This will erase all cookies and session data. Do you really want to change your account?</string>
 
+    <string name="pref_title_clear_cache">Clear cache</string>
+    <string name="pref_desc_clear_cache">Clear WebView cache</string>
+
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -52,6 +52,12 @@
             android:summary="@string/pref_desc_load_images"
             android:defaultValue="true" />
 
+        <Preference
+            android:title="@string/pref_title_clear_cache"
+            android:key="pref_key_clear_cache"
+            android:summary="@string/pref_desc_clear_cache">
+        </Preference>
+
         <CheckBoxPreference
             android:title="@string/pref_title_proxy_enabled"
             android:key="pref_key_proxy_enabled"


### PR DESCRIPTION
I was going to add a simple option, but noticed that `startActivityForResult()` does not work for `SettingsActivity` (at least on Android 4.4; it seems it just don't work for any activity that uses `android:launchMode="singleInstance"`, [discussed here](https://stackoverflow.com/questions/11919259/how-to-get-startactivityforresult-on-external-activity-to-work)), so any option that used `SettingsActivity.setResult()` to deliver result did not work.

I hastily fixed it (probably hackish), so you are free to decline the PR, but please look into the problem. BTW, if you decline the PR, you want to add `break`s or `return`s to the `switch` (the one I updated) to prevent unwanted fall through.
