### PR TITLE
A fix and a small feature

### DIFF
--- a/app/src/main/java/com/github/dfa/diaspora_android/activity/SettingsActivity.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/activity/SettingsActivity.java
@@ -94,8 +94,7 @@ public class SettingsActivity extends AppCompatActivity {
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
             updatePreference(findPreference(key));
-            if (key != null && isAdded() && (key.equals(getString(R.string.pref_key__clear_cache)) ||
-                    key.equals(getString(R.string.pref_key__font_size)) ||
+            if (key != null && isAdded() && (key.equals(getString(R.string.pref_key__font_size)) ||
                     key.equals(getString(R.string.pref_key__load_images)) ||
                     key.equals(getString(R.string.pref_key__intellihide_toolbars)) ||
                     key.equals(getString(R.string.pref_key__proxy_enabled)) ||
@@ -157,6 +156,10 @@ public class SettingsActivity extends AppCompatActivity {
                                     })
                             .show();
                     return true;
+                }
+                case R.string.pref_title__clear_cache: {
+                    intent.setAction(MainActivity.ACTION_CLEAR_CACHE);
+                    break;
                 }
 
                 default: {

--- a/app/src/main/java/com/github/dfa/diaspora_android/data/AppSettings.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/data/AppSettings.java
@@ -260,6 +260,10 @@ public class AppSettings {
         return getBoolean(prefApp, R.string.pref_key__chrome_custom_tabs_enabled, true);
     }
 
+    public boolean isPostContextMenuEnabled() {
+        return getBoolean(prefApp, R.string.pref_key__post_link_context_menu_enabled, false);
+    }
+
     public boolean isLoggingEnabled() {
         return getBoolean(prefApp, R.string.pref_key__logging_enabled, true);
     }

--- a/app/src/main/java/com/github/dfa/diaspora_android/ui/ContextMenuWebView.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/ui/ContextMenuWebView.java
@@ -37,9 +37,11 @@ import android.view.ContextMenu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
+import com.github.dfa.diaspora_android.App;
 import com.github.dfa.diaspora_android.R;
 import com.github.dfa.diaspora_android.activity.MainActivity;
 import com.github.dfa.diaspora_android.task.ImageDownloadTask;
+import com.github.dfa.diaspora_android.util.DiasporaUrlHelper;
 
 import java.io.File;
 
@@ -55,6 +57,7 @@ public class ContextMenuWebView extends NestedWebView {
     public static final int ID_COPY_LINK = 12;
     public static final int ID_SHARE_LINK = 13;
     public static final int ID_SHARE_IMAGE = 14;
+    public static final int ID_OPEN_HERE = 15;
 
     private final Context context;
     private Activity parentActivity;
@@ -195,6 +198,13 @@ public class ContextMenuWebView extends NestedWebView {
                                     .getText(R.string.context_menu_share_link)));
                         }
                         break;
+
+                    //Open link in the webview
+                    case ID_OPEN_HERE:
+                        if (url != null) {
+                            loadUrlNew(url);
+                        }
+                        break;
                 }
                 return true;
             }
@@ -212,6 +222,10 @@ public class ContextMenuWebView extends NestedWebView {
                 result.getType() == HitTestResult.SRC_ANCHOR_TYPE) {
             // Menu options for a hyperlink.
             menu.setHeaderTitle(result.getExtra());
+            String url = result.getExtra();
+            if (url != null && new DiasporaUrlHelper(((App)parentActivity.getApplication()).getSettings()).isPostUrl(url)) {
+                menu.add(0, ID_OPEN_HERE, 0, context.getString(R.string.context_menu_open_here)).setOnMenuItemClickListener(handler);
+            }
             menu.add(0, ID_COPY_LINK, 0, context.getString(R.string.context_menu_copy_link)).setOnMenuItemClickListener(handler);
             menu.add(0, ID_SHARE_LINK, 0, context.getString(R.string.context_menu_share_link)).setOnMenuItemClickListener(handler);
         }

--- a/app/src/main/java/com/github/dfa/diaspora_android/util/DiasporaUrlHelper.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/util/DiasporaUrlHelper.java
@@ -23,6 +23,8 @@ import com.github.dfa.diaspora_android.R;
 import com.github.dfa.diaspora_android.data.AppSettings;
 import com.github.dfa.diaspora_android.data.PodAspect;
 
+import java.util.regex.Pattern;
+
 /**
  * Helper class that provides easy access to specific urls related to diaspora
  * Created by vanitasvitae on 10.08.16.
@@ -50,6 +52,8 @@ public class DiasporaUrlHelper {
     public static final String SUBURL_ASPECTS = "/aspects";
     public static final String SUBURL_STATISTICS = "/statistics";
     public static final String URL_BLANK = "about:blank";
+
+    public static final Pattern NUMBERS_ONLY_PATTERN = Pattern.compile("^\\d+$");
 
     public DiasporaUrlHelper(AppSettings settings) {
         this.settings = settings;
@@ -236,5 +240,16 @@ public class DiasporaUrlHelper {
         } catch (Exception ignored) {
         }
         return app.getString(R.string.aspects);
+    }
+
+    public boolean isPostUrl(String url) {
+        if (url.startsWith(getPodUrl() + SUBURL_POSTS)) {
+            String path = url.substring((getPodUrl() + SUBURL_POSTS).length());
+            if (NUMBERS_ONLY_PATTERN.matcher(path).matches()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/src/main/java/com/github/dfa/diaspora_android/webview/CustomWebViewClient.java
+++ b/app/src/main/java/com/github/dfa/diaspora_android/webview/CustomWebViewClient.java
@@ -27,6 +27,7 @@ import android.webkit.WebViewClient;
 
 import com.github.dfa.diaspora_android.App;
 import com.github.dfa.diaspora_android.activity.MainActivity;
+import com.github.dfa.diaspora_android.util.DiasporaUrlHelper;
 
 public class CustomWebViewClient extends WebViewClient {
     private final App app;
@@ -43,6 +44,10 @@ public class CustomWebViewClient extends WebViewClient {
             Intent i = new Intent(MainActivity.ACTION_OPEN_EXTERNAL_URL);
             i.putExtra(MainActivity.EXTRA_URL, url);
             LocalBroadcastManager.getInstance(app.getApplicationContext()).sendBroadcast(i);
+            return true;
+        } else if (app.getSettings().isPostContextMenuEnabled()
+                && new DiasporaUrlHelper(app.getSettings()).isPostUrl(url)) {
+            view.showContextMenu();
             return true;
         }
         return false;

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -46,6 +46,7 @@
 
     <!-- More -->
     <string name="pref_catkey__category_more" translatable="false">pref_catkey__category_more</string>
+    <string name="pref_key__post_link_context_menu_enabled" translatable="false">pref_key__post_link_context_menu_enabled</string>
     <string name="pref_key__logging_spam_enabled" translatable="false">pref_key__logging_spam_enabled</string>
     <string name="pref_key__logging_enabled" translatable="false">pref_key__logging_enabled</string>
 
@@ -118,6 +119,9 @@
     <string name="pref_desc__append_shared_via_app">Append a reference to this app ("shared by…") to shared texts</string>
 
     <!-- More -->
+    <string name="pref_title__post_link_context_menu_enabled">Context menu for post links</string>
+    <string name="pref_desc__post_link_context_menu_enabled">Open context menu for post links with short press</string>
+
     <string name="pref_title__sub_logging" translatable="false">@string/about_activity__title_debug_info</string>
     <string name="pref_desc__sub_logging" translatable="false">@string/fragment_debug__section_log</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="context_menu_share_image">Share image</string>
     <string name="context_menu_open_external_browser">Open in external browser…</string>
     <string name="context_menu_copy_link">Copy link address to clipboard</string>
+    <string name="context_menu_open_here">Open link</string>
 
 
     <!-- More from MainActivity -->

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -152,6 +152,12 @@
         android:key="@string/pref_catkey__category_more"
         android:title="@string/pref_cat__more">
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key__post_link_context_menu_enabled"
+            android:title="@string/pref_title__post_link_context_menu_enabled"
+            android:summary="@string/pref_desc__post_link_context_menu_enabled"/>
+
         <PreferenceScreen
             android:summary="@string/pref_desc__sub_logging"
             android:title="@string/pref_title__sub_logging">


### PR DESCRIPTION
Fixes "Clear cache" option which was broken since [08b39b1](https://github.com/Diaspora-for-Android/diaspora-android/commit/08b39b16c9a4a336c5fde47577f3bb29108d5bf5). The option does not require restart.

Adds an option to open context menu for post links (`https://POD/posts/ID`) with short press. Rationale: I mostly use mobile client to save links to read them later, but sharing post links has become tedious (long press requires you to hold the link without moving even for a pixel).
